### PR TITLE
Update video file name processing to be platform agnostic.

### DIFF
--- a/video_demo.py
+++ b/video_demo.py
@@ -12,6 +12,7 @@ from dataloader import VideoLoader, DetectionLoader, DetectionProcessor, DataWri
 from yolo.util import write_results, dynamic_write_results
 from SPPE.src.main_fast_inference import *
 
+import ntpath
 import os
 import sys
 from tqdm import tqdm
@@ -62,7 +63,7 @@ if __name__ == "__main__":
     }
 
     # Data writer
-    save_path = os.path.join(args.outputpath, 'AlphaPose_'+videofile.split('/')[-1].split('.')[0]+'.avi')
+    save_path = os.path.join(args.outputpath, 'AlphaPose_'+ntpath.basename(videofile).split('.')[0]+'.avi')
     writer = DataWriter(args.save_video, save_path, cv2.VideoWriter_fourcc(*'XVID'), fps, frameSize).start()
 
     im_names_desc =  tqdm(range(data_loader.length()))


### PR DESCRIPTION
Source: https://stackoverflow.com/questions/8384737/extract-file-name-from-path-no-matter-what-the-os-path-format

Reference: #121 