### PR TITLE
Speed up Poseflow by parallelizing orb matching

### DIFF
--- a/PoseFlow/parallel_process.py
+++ b/PoseFlow/parallel_process.py
@@ -1,0 +1,49 @@
+# adapted from http://danshiebler.com/2016-09-14-parallel-progress-bar/
+from tqdm import tqdm
+from concurrent.futures import ProcessPoolExecutor, as_completed
+
+def parallel_process(array, function, n_jobs=16, use_kwargs=False, front_num=3):
+    """
+        A parallel version of the map function with a progress bar. 
+
+        Args:
+            array (array-like): An array to iterate over.
+            function (function): A python function to apply to the elements of array
+            n_jobs (int, default=16): The number of cores to use
+            use_kwargs (boolean, default=False): Whether to consider the elements of array as dictionaries of 
+                keyword arguments to function 
+            front_num (int, default=3): The number of iterations to run serially before kicking off the parallel job. 
+                Useful for catching bugs
+        Returns:
+            [function(array[0]), function(array[1]), ...]
+    """
+    #We run the first few iterations serially to catch bugs
+    if front_num > 0:
+        front = [function(**a) if use_kwargs else function(*a) for a in array[:front_num]]
+    #If we set n_jobs to 1, just run a list comprehension. This is useful for benchmarking and debugging.
+    if n_jobs==1:
+        return front + [function(**a) if use_kwargs else function(*a) for a in tqdm(array[front_num:])]
+    #Assemble the workers
+    with ProcessPoolExecutor(max_workers=n_jobs) as pool:
+        #Pass the elements of array into function
+        if use_kwargs:
+            futures = [pool.submit(function, **a) for a in array[front_num:]]
+        else:
+            futures = [pool.submit(function, *a) for a in array[front_num:]]
+        kwargs = {
+            'total': len(futures),
+            'unit': 'it',
+            'unit_scale': True,
+            'leave': True
+        }
+        #Print out the progress as tasks complete
+        for f in tqdm(as_completed(futures), **kwargs):
+            pass
+    out = []
+    #Get the results from the futures. 
+    for i, future in enumerate(futures):
+        try:
+            out.append(future.result())
+        except Exception as e:
+            out.append(e)
+    return front + out

--- a/PoseFlow/tracker-general.py
+++ b/PoseFlow/tracker-general.py
@@ -77,11 +77,6 @@ def display_pose(imgdir, visdir, tracked, cmap):
         plt.close()
 
 
-
-
-
-
-
 if __name__ == '__main__':
     
     parser = argparse.ArgumentParser(description='FoseFlow Tracker')
@@ -198,7 +193,6 @@ if __name__ == '__main__':
                     track[frame_name][pid]['new_pid'] = pid
                     track[frame_name][pid]['match_score'] = 0
 
-
         max_pid_id = max(max_pid_id, track[frame_name]['num_boxes'])
         cor_file = os.path.join(image_dir, "".join([frame_id, '_', next_frame_id, '_orb.txt']))
         all_cors = np.loadtxt(cor_file)
@@ -242,8 +236,6 @@ if __name__ == '__main__':
 
     with open(tracked_json,'w') as json_file:
         json_file.write(json.dumps(notrack))
-
-
 
     if len(args.visdir)>0:
         cmap = plt.cm.get_cmap("hsv", num_persons)

--- a/PoseFlow/tracker-general.py
+++ b/PoseFlow/tracker-general.py
@@ -17,7 +17,6 @@ import os
 import json
 import copy
 import heapq
-import time
 from munkres import Munkres, print_matrix
 from PIL import Image
 import matplotlib.pyplot as plt
@@ -25,8 +24,6 @@ from tqdm import tqdm
 from utils import *
 from matching import orb_matching
 import argparse
-from functools import partial
-from itertools import repeat
 import multiprocessing
 from parallel_process import parallel_process
 
@@ -122,8 +119,6 @@ if __name__ == '__main__':
     tracked_json = args.out_json
     image_dir = args.imgdir
     vis_dir = args.visdir
-
-    start_time = time.time()
 
     # if json format is differnt from "alphapose-forvis.json" (pytorch version)
     if "forvis" not in notrack_json:
@@ -238,8 +233,6 @@ if __name__ == '__main__':
         for pid in range(1, track[frame_name]['num_boxes']+1):
             num_persons = max(num_persons, track[frame_name][pid]['new_pid'])
     print("This video contains %d people."%(num_persons))
-
-    print("Tracking took: ", time.time() - start_time, " seconds" )
 
     # export tracking result into notrack json files
     print("Export tracking results to json...\n")


### PR DESCRIPTION
The matching of frame pairs using orb_matching is very compute intensive and can be processed in parallel as there is no dependence on previous frames. In this PR, multiprocessing is used to pool the processing onto multiple cores. The `ProcessPoolExecutor` pools the processing into `n_jobs` processes, this variable might need to be adjusted depending on the number of cpu cores. 