### PR TITLE
Addition of missing qsize arg for DetectionLoader

### DIFF
--- a/scripts/demo_inference.py
+++ b/scripts/demo_inference.py
@@ -148,7 +148,7 @@ if __name__ == "__main__":
     if mode == 'webcam':
         det_loader = WebCamDetectionLoader(input_source, get_detector(args), cfg, args).start()
     else:
-        det_loader = DetectionLoader(input_source, get_detector(args), cfg, args, batchSize=args.detbatch, mode=mode).start()
+        det_loader = DetectionLoader(input_source, get_detector(args), cfg, args, batchSize=args.detbatch, mode=mode, queueSize=args.qsize).start()
 
     # Load pose model
     pose_model = builder.build_sppe(cfg.MODEL, preset_cfg=cfg.DATA_PRESET)


### PR DESCRIPTION
Missing --qsize arg for the DetectionLoader class. This helps with issue #435 to at least get it running on lower memory machines. More work probably need elsewhere though to full resolve