### PR TITLE
update --save_img problem and not sorted(alphabetically) in demo_inference problem

### DIFF
--- a/alphapose/utils/vis.py
+++ b/alphapose/utils/vis.py
@@ -183,7 +183,7 @@ def vis_frame_fast(frame, im_res, add_bbox=False, format='coco'):
             if start_p in part_line and end_p in part_line:
                 start_xy = part_line[start_p]
                 end_xy = part_line[end_p]
-                cv2.line(img, start_xy, end_xy, line_color[i], 2 * (kp_scores[start_p] + kp_scores[end_p]) + 1)
+                cv2.line(img, start_xy, end_xy, line_color[i], 2 * int(kp_scores[start_p] + kp_scores[end_p]) + 1)
     return img
 
 

--- a/scripts/demo_inference.py
+++ b/scripts/demo_inference.py
@@ -8,6 +8,7 @@ import time
 import numpy as np
 import torch
 from tqdm import tqdm
+import natsort
 
 from detector.apis import get_detector
 from alphapose.models import builder
@@ -127,6 +128,7 @@ def check_input():
         elif len(inputpath) and inputpath != '/':
             for root, dirs, files in os.walk(inputpath):
                 im_names = files
+            im_names = natsort.natsorted(im_names)
         elif len(inputimg):
             im_names = [inputimg]
 


### PR DESCRIPTION
1. First is about --save_img problem:

The original problem is that it cannot save images in  #628 
in alphapose/utils/vis.py 
in line 186 change to =>"cv2.line(img, start_xy, end_xy, line_color[i], 2 * int(kp_scores[start_p] + kp_scores[end_p]) + 1)" will solve the problem

2. Second is about sorted problem:

in scripts/demo_inference.py
add "import natsorted"
and line 131 add "im_names = natsort.natsorted(im_names)"

Thank you~
Chris Hsu