### PR TITLE
Fix bug in bench.py

### DIFF
--- a/detector/efficientdet/effdet/bench.py
+++ b/detector/efficientdet/effdet/bench.py
@@ -32,7 +32,7 @@ def _post_process(config, cls_outputs, box_outputs):
         for level in range(config.num_levels)], 1)
 
     _, cls_topk_indices_all = torch.topk(cls_outputs_all.reshape(batch_size, -1), dim=1, k=MAX_DETECTION_POINTS)
-    indices_all = cls_topk_indices_all / config.num_classes
+    indices_all = cls_topk_indices_all // config.num_classes
     classes_all = cls_topk_indices_all % config.num_classes
 
     box_outputs_all_after_topk = torch.gather(


### PR DESCRIPTION
Fix bug occurred in torch.gather: `RuntimeError: gather_out_cuda(): Expected dtype int64 for index`

According to the [document of torch.gather](https://pytorch.org/docs/stable/generated/torch.gather.html?highlight=torch%20gather#torch.gather), the parameter index must be a LongTensor, instead of float type.
Otherwise the following error will occur when using the efficientdet as the detector:
```
Process Process-2:
Traceback (most recent call last):
  File "/home/frank/miniconda3/envs/alphapose/lib/python3.6/multiprocessing/process.py", line 258, in _bootstrap
    self.run()
  File "/home/frank/miniconda3/envs/alphapose/lib/python3.6/multiprocessing/process.py", line 93, in run
    self._target(*self._args, **self._kwargs)
  File "/home/frank/Projects/Action/AlphaPose/alphapose/utils/detector.py", line 223, in image_detection
    dets = self.detector.images_detection(imgs, im_dim_list)
  File "/home/frank/Projects/Action/AlphaPose/detector/effdet_api.py", line 110, in images_detection
    prediction = self.model(imgs, scaling_factors)
  File "/home/frank/miniconda3/envs/alphapose/lib/python3.6/site-packages/torch/nn/modules/module.py", line 889, in _call_impl
    result = self.forward(*input, **kwargs)
  File "/home/frank/Projects/Action/AlphaPose/detector/efficientdet/effdet/bench.py", line 63, in forward
    class_out, box_out, indices, classes = _post_process(self.config, class_out, box_out)
  File "/home/frank/Projects/Action/AlphaPose/detector/efficientdet/effdet/bench.py", line 39, in _post_process
    box_outputs_all, 1, indices_all.unsqueeze(2).expand(-1, -1, 4))
RuntimeError: gather_out_cuda(): Expected dtype int64 for index
```
My pytorch version is 1.8.1+cu111