### PR TITLE
Resolved getting stuck when using multiprocessing

### DIFF
--- a/alphapose/utils/writer.py
+++ b/alphapose/utils/writer.py
@@ -94,14 +94,18 @@ class DataWriter():
             assert stream.isOpened(), 'Cannot open video for writing'
         # keep looping infinitelyd
         while True:
-            # ensure the queue is not empty and get item
-            (boxes, scores, ids, hm_data, cropped_boxes, orig_img, im_name) = self.wait_and_get(self.result_queue)
+            if not self.result_queue.empty():
+                # ensure the queue is not empty and get item
+                (boxes, scores, ids, hm_data, cropped_boxes, orig_img, im_name) = self.wait_and_get(self.result_queue)
+            else:
+                continue
             if orig_img is None:
                 # if the thread indicator variable is set (img is None), stop the thread
                 if self.save_video:
                     stream.release()
                 write_json(final_result, self.opt.outputpath, form=self.opt.format, for_eval=self.opt.eval)
                 print("Results have been written to json.")
+                self.save(None, None, None, None, None, None, None)
                 return
             # image channel RGB->BGR
             orig_img = np.array(orig_img, dtype=np.uint8)[:, :, ::-1]


### PR DESCRIPTION
When using multiprocessing, writer.stop() in demo script will only finish one process while others remain in stuck result_queue.get().
In order to finish all the processes simply added self.save(None * 7) right before one finishes, so that next process can finish in a row.
Additionally, added a condition checking if result_queue is empty.
Any other descent ways to resolve this issue would be nice.

If this is the case, write_json would not work properly since only the last process will overwrite and store partial result data.