### PR TITLE
refactor: 直接提供bbox_iou函数，以取消Cython依赖

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -102,6 +102,7 @@ venv.bak/
 # mypy
 .mypy_cache/
 .vscode
+.idea
 .tensorboard
 exp/coco*
 *.pth
@@ -114,5 +115,5 @@ data/
 tmp/
 exp/json
 tmp_*/
-example/res/
+examples/res/
 data/

--- a/setup.py
+++ b/setup.py
@@ -216,7 +216,3 @@ if __name__ == '__main__':
         print("\nInstall third-party pycocotools for Windows...")
         cmd = 'python -m pip install git+https://github.com/philferriere/cocoapi.git#subdirectory=PythonAPI'
         os.system(cmd)
-    if not is_installed('cython_bbox'):
-        print("\nInstall `cython_bbox`...")
-        cmd = 'python -m pip install git+https://github.com/yanfengliu/cython_bbox.git'
-        os.system(cmd)

--- a/trackers/tracking/matching.py
+++ b/trackers/tracking/matching.py
@@ -4,9 +4,40 @@ import scipy
 from scipy.spatial.distance import cdist
 from scipy.optimize import linear_sum_assignment
 
-from cython_bbox import bbox_overlaps as bbox_ious
 from trackers.utils import kalman_filter
-import time
+import math
+import torch
+
+def bbox_iou(box1, box2, eps=1e-7): # CIoU
+    # Returns the IoU of box1 to box2. box1 is 4, box2 is nx4
+    box2 = box2.T
+
+    # Get the coordinates of bounding boxes
+    b1_x1, b1_y1, b1_x2, b1_y2 = box1[0], box1[1], box1[2], box1[3]
+    b2_x1, b2_y1, b2_x2, b2_y2 = box2[0], box2[1], box2[2], box2[3]
+
+    # Intersection area
+    inter = (torch.min(b1_x2, b2_x2) - torch.max(b1_x1, b2_x1)).clamp(0) * \
+            (torch.min(b1_y2, b2_y2) - torch.max(b1_y1, b2_y1)).clamp(0)
+
+    # Union Area
+    w1, h1 = b1_x2 - b1_x1, b1_y2 - b1_y1 + eps
+    w2, h2 = b2_x2 - b2_x1, b2_y2 - b2_y1 + eps
+    union = w1 * h1 + w2 * h2 - inter + eps
+
+    iou = inter / union
+    cw = torch.max(b1_x2, b2_x2) - torch.min(b1_x1, b2_x1)  # convex (smallest enclosing box) width
+    ch = torch.max(b1_y2, b2_y2) - torch.min(b1_y1, b2_y1)  # convex height
+
+    c2 = cw ** 2 + ch ** 2 + eps  # convex diagonal squared
+    rho2 = ((b2_x1 + b2_x2 - b1_x1 - b1_x2) ** 2 +
+            (b2_y1 + b2_y2 - b1_y1 - b1_y2) ** 2) / 4  # center distance squared
+
+    v = (4 / math.pi ** 2) * torch.pow(torch.atan(w2 / h2) - torch.atan(w1 / h1), 2)
+    with torch.no_grad():
+        alpha = v / (v - iou + (1 + eps))
+    return iou - (rho2 / c2 + v * alpha)  # CIoU
+
 
 def merge_matches(m1, m2, shape):
     O,P,Q = shape
@@ -65,7 +96,7 @@ def ious(atlbrs, btlbrs):
     if ious.size == 0:
         return ious
 
-    ious = bbox_ious(
+    ious = bbox_iou(
         np.ascontiguousarray(atlbrs, dtype=np.float),
         np.ascontiguousarray(btlbrs, dtype=np.float)
     )


### PR DESCRIPTION
我在进行推理的时候发现需要安装Cython，他还需要cpp环境。而整个项目中使用到Cython的地方只有iou，为此我直接添加进了iou函数，感觉这样会更加简便。可以看看是否需要合并。