### PR TITLE
Support Numpy >= 1.24

### DIFF
--- a/detector/tracker/tracker/matching.py
+++ b/detector/tracker/tracker/matching.py
@@ -8,6 +8,9 @@ from cython_bbox import bbox_overlaps as bbox_ious
 from tracker.utils import kalman_filter
 import time
 
+# np.float removed in Numpy 1.24
+DTYPE_FLOAT = np.float if hasattr(np, "float") else float
+
 def merge_matches(m1, m2, shape):
     O,P,Q = shape
     m1 = np.asarray(m1)
@@ -61,13 +64,13 @@ def ious(atlbrs, btlbrs):
 
     :rtype ious np.ndarray
     """
-    ious = np.zeros((len(atlbrs), len(btlbrs)), dtype=np.float)
+    ious = np.zeros((len(atlbrs), len(btlbrs)), dtype=DTYPE_FLOAT)
     if ious.size == 0:
         return ious
 
     ious = bbox_ious(
-        np.ascontiguousarray(atlbrs, dtype=np.float),
-        np.ascontiguousarray(btlbrs, dtype=np.float)
+        np.ascontiguousarray(atlbrs, dtype=DTYPE_FLOAT),
+        np.ascontiguousarray(btlbrs, dtype=DTYPE_FLOAT)
     )
 
     return ious
@@ -101,10 +104,10 @@ def embedding_distance(tracks, detections, metric='cosine'):
     :return: cost_matrix np.ndarray
     """
 
-    cost_matrix = np.zeros((len(tracks), len(detections)), dtype=np.float)
+    cost_matrix = np.zeros((len(tracks), len(detections)), dtype=DTYPE_FLOAT)
     if cost_matrix.size == 0:
         return cost_matrix
-    det_features = np.asarray([track.curr_feat for track in detections], dtype=np.float)
+    det_features = np.asarray([track.curr_feat for track in detections], dtype=DTYPE_FLOAT)
     for i, track in enumerate(tracks):
         cost_matrix[i, :] = np.maximum(0.0, cdist(track.smooth_feat.reshape(1,-1), det_features, metric))
     return cost_matrix

--- a/detector/tracker/tracker/multitracker.py
+++ b/detector/tracker/tracker/multitracker.py
@@ -13,13 +13,15 @@ from tracker.models import *
 from tracker.tracker import matching
 from tracker.tracker.basetrack import BaseTrack, TrackState
 
+# np.float removed in Numpy 1.24
+DTYPE_FLOAT = np.float if hasattr(np, "float") else float
 
 class STrack(BaseTrack):
 
     def __init__(self, tlwh, score, temp_feat, buffer_size=30):
 
         # wait activate
-        self._tlwh = np.asarray(tlwh, dtype=np.float)
+        self._tlwh = np.asarray(tlwh, dtype=DTYPE_FLOAT)
         self.kalman_filter = None
         self.mean, self.covariance = None, None
         self.is_activated = False

--- a/trackers/ReidModels/net_utils.py
+++ b/trackers/ReidModels/net_utils.py
@@ -9,6 +9,8 @@ import pickle
 
 from utils.log import logger
 
+# np.float removed in Numpy 1.24
+DTYPE_FLOAT = np.float if hasattr(np, "float") else float
 
 class ConcatAddTable(nn.Module):
     def __init__(self, *args):
@@ -127,7 +129,7 @@ def load_net(fname, net, prefix='', load_state_dict=False):
                 lr = h5f.attrs['learning_rates']
             else:
                 lr = h5f.attrs.get('lr', -1)
-                lr = np.asarray([lr] if lr > 0 else [], dtype=np.float)
+                lr = np.asarray([lr] if lr > 0 else [], dtype=DTYPE_FLOAT)
 
             return epoch, lr
 

--- a/trackers/tracker_api.py
+++ b/trackers/tracker_api.py
@@ -29,13 +29,16 @@ from ReidModels.osnet import *
 from ReidModels.osnet_ain import osnet_ain_x1_0
 from ReidModels.resnet_fc import resnet50_fc512
 
+# np.float removed in Numpy 1.24
+DTYPE_FLOAT = np.float if hasattr(np, "float") else float
+
 class STrack(BaseTrack):
     shared_kalman = KalmanFilter()
 
     def __init__(self, tlwh, score, temp_feat, pose,crop_box,file_name,ps,buffer_size=30):
 
         # wait activate
-        self._tlwh = np.asarray(tlwh, dtype=np.float)
+        self._tlwh = np.asarray(tlwh, dtype=DTYPE_FLOAT)
         self.kalman_filter = None
         self.mean, self.covariance = None, None
         self.is_activated = False

--- a/trackers/tracking/matching.py
+++ b/trackers/tracking/matching.py
@@ -8,6 +8,9 @@ from cython_bbox import bbox_overlaps as bbox_ious
 from trackers.utils import kalman_filter
 import time
 
+# np.float removed in Numpy 1.24
+DTYPE_FLOAT = np.float if hasattr(np, "float") else float
+
 def merge_matches(m1, m2, shape):
     O,P,Q = shape
     m1 = np.asarray(m1)
@@ -61,13 +64,13 @@ def ious(atlbrs, btlbrs):
 
     :rtype ious np.ndarray
     """
-    ious = np.zeros((len(atlbrs), len(btlbrs)), dtype=np.float)
+    ious = np.zeros((len(atlbrs), len(btlbrs)), dtype=DTYPE_FLOAT)
     if ious.size == 0:
         return ious
 
     ious = bbox_ious(
-        np.ascontiguousarray(atlbrs, dtype=np.float),
-        np.ascontiguousarray(btlbrs, dtype=np.float)
+        np.ascontiguousarray(atlbrs, dtype=DTYPE_FLOAT),
+        np.ascontiguousarray(btlbrs, dtype=DTYPE_FLOAT)
     )
 
     return ious
@@ -101,10 +104,10 @@ def embedding_distance(tracks, detections, metric='cosine'):
     :return: cost_matrix np.ndarray
     """
 
-    cost_matrix = np.zeros((len(tracks), len(detections)), dtype=np.float)
+    cost_matrix = np.zeros((len(tracks), len(detections)), dtype=DTYPE_FLOAT)
     if cost_matrix.size == 0:
         return cost_matrix
-    det_features = np.asarray([track.curr_feat for track in detections], dtype=np.float)
+    det_features = np.asarray([track.curr_feat for track in detections], dtype=DTYPE_FLOAT)
     for i, track in enumerate(tracks):
         cost_matrix[i, :] = np.maximum(0.0, cdist(track.smooth_feat.reshape(1,-1), det_features, metric))
     return cost_matrix

--- a/trackers/utils/bbox.py
+++ b/trackers/utils/bbox.py
@@ -1,6 +1,8 @@
 import numpy as np
 import cv2
 
+# np.float removed in Numpy 1.24
+DTYPE_FLOAT = np.float if hasattr(np, "float") else float
 
 def clip_boxes(boxes, im_shape):
     """
@@ -33,7 +35,7 @@ def clip_box(bbox, im_shape):
 
 
 def int_box(box):
-    box = np.asarray(box, dtype=np.float)
+    box = np.asarray(box, dtype=DTYPE_FLOAT)
     box = np.round(box)
     return np.asarray(box, dtype=np.int)
 


### PR DESCRIPTION
Numpy data type alias `np.float` has been removed by expired deprecation in version 1.24.

Related issue: #1107