### PR TITLE
Improving performance of tracker in inference time

### DIFF
--- a/trackers/__init__.py
+++ b/trackers/__init__.py
@@ -16,5 +16,5 @@ def track(tracker,args,orig_img,inps,boxes,hm,cropped_boxes,im_name,scores):
         new_ids.append(tid)
         new_scores.append(tscore)
 
-    new_hm = torch.Tensor(new_hm).to(args.device)
+    new_hm = torch.from_numpy(np.array(new_hm)).to(args.device)
     return new_boxes,new_scores,new_ids,new_hm,new_crop


### PR DESCRIPTION
Instead of copying the tensor, use the same memory by converting to NumPy array first.
By doing so, You can improve the inference time of the tracker (On my computer it was 10ms per single process).