### PR TITLE
Fix the version dependency problem in install.md

### DIFF
--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -22,31 +22,32 @@ Install conda from [here](https://repo.anaconda.com/miniconda/), Miniconda3-late
 conda create -n alphapose python=3.7 -y
 conda activate alphapose
 
-# 2. Install PyTorch
-conda install pytorch torchvision torchaudio pytorch-cuda=11.3 -c pytorch -c nvidia 
+# 2. Install specific pytorch version
+conda install pytorch==1.12.1 torchvision==0.13.1 torchaudio==0.12.1 cudatoolkit=11.3 -c pytorch
 
 # 3. Get AlphaPose
 git clone https://github.com/MVIG-SJTU/AlphaPose.git
 cd AlphaPose
 
-
-# 4. install
+# 4. install dependencies
 export PATH=/usr/local/cuda/bin/:$PATH
 export LD_LIBRARY_PATH=/usr/local/cuda/lib64/:$LD_LIBRARY_PATH
-python -m pip install cython
 sudo apt-get install libyaml-dev
+pip install cython==0.27.3 ninja easydict halpecocotools munkres natsort opencv-python pyyaml scipy tensorboardx  terminaltables timm==0.1.20 tqdm visdom jinja2 typeguard pycocotools
 ################Only For Ubuntu 18.04#################
 locale-gen C.UTF-8
 # if locale-gen not found
 sudo apt-get install locales
 export LANG=C.UTF-8
 ######################################################
+
+# 5. install AlphaPose 
 python setup.py build develop
 
-# 5. Install PyTorch3D (Optional, only for visualization)
+# 6. Install PyTorch3D (Optional, only for visualization)
 conda install -c fvcore -c iopath -c conda-forge fvcore iopath
 conda install -c bottler nvidiacub
-pip install git+ssh://git@github.com/facebookresearch/pytorch3d.git@stable
+pip install pytorch3d
 ```
 
 #### Install with pip


### PR DESCRIPTION
The installation guide in the install.md file has problems and cannot be reproduced. According to the repaired installation guide, conda can be used to install and test correctly.

Fix the version dependency problem in install.md
reproduced in [my blog article](https://blog.csdn.net/m0_56661101/article/details/131780054) at 2023/07/19 with Ubuntu22.04 & Conda.