### PR TITLE
Fix bug in roi_align.py 

### DIFF
--- a/alphapose/utils/roi_align/roi_align.py
+++ b/alphapose/utils/roi_align/roi_align.py
@@ -3,7 +3,6 @@ from torch.autograd import Function
 from torch.autograd.function import once_differentiable
 from torch.nn.modules.utils import _pair
 
-from . import roi_align_cuda
 
 
 class RoIAlignFunction(Function):


### PR DESCRIPTION
I modified a circular reference error.
This commit can solve issue #1061 

My environment is below:
- CUDA: 11.0
- CuDNN: 8.5.0