### PR TITLE
Update CPU-only support for building the project. 更新对仅CPU构建的支持

### DIFF
--- a/alphapose/utils/roi_align/roi_align.py
+++ b/alphapose/utils/roi_align/roi_align.py
@@ -3,8 +3,10 @@ from torch.autograd import Function
 from torch.autograd.function import once_differentiable
 from torch.nn.modules.utils import _pair
 
-from . import roi_align_cuda
-
+try:
+    from . import roi_align_cuda
+except ImportError:
+    print("Import roi_align_cuda module failed, skipping...")
 
 class RoIAlignFunction(Function):
 

--- a/detector/nms/nms_wrapper.py
+++ b/detector/nms/nms_wrapper.py
@@ -1,7 +1,11 @@
 import numpy as np
 import torch
 
-from . import nms_cpu, nms_cuda
+try:
+    from . import nms_cpu, nms_cuda
+except ImportError:
+    print("Import nms_cpu and nms_cuda failed, importing only nms_cpu...")
+    from . import nms_cpu
 from .soft_nms_cpu import soft_nms_cpu
 
 


### PR DESCRIPTION
Setup.py adds CUDA extensions based on whether there is a GPU or not. If not presented, add CPU extensions only. Also added exception handling for module importing where error may occur.

在setup.py中添加了判断有没有GPU以决定是否添加GPU相关扩展。将nms_cpu的构建工具改为`torch.utils.cpp_extension`的`CppExtension`。在使用构建的模块的地方添加了try-except以防止程序因找不到模块而中断。