### PR TITLE
Update matching.py

### DIFF
--- a/trackers/tracking/matching.py
+++ b/trackers/tracking/matching.py
@@ -1,5 +1,6 @@
 import cv2
 import numpy as np
+np.float = float
 import scipy
 from scipy.spatial.distance import cdist
 from scipy.optimize import linear_sum_assignment


### PR DESCRIPTION
AlphaPose gives compatibility issue due to newer versions of NumPy, specifically np.float being deprecated.

Solution for the following AttributeError: module 'numpy' has no attribute 'float'.